### PR TITLE
not required for trusty which will be the default one in the future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 language: bash
 services:
 - docker


### PR DESCRIPTION
They are updating the images